### PR TITLE
Failing to create variables in euler1d.py

### DIFF
--- a/cpp/modmesh/onedim/Euler1DCore.cpp
+++ b/cpp/modmesh/onedim/Euler1DCore.cpp
@@ -49,6 +49,7 @@ void Euler1DCore::initialize_data(size_t ncoord)
     {
         throw std::invalid_argument("ncoord cannot be even");
     }
+    m_pt_plot = SimpleArray<int>(/*length*/ ((ncoord - 3) / 2));
     m_coord = SimpleArray<double>(/*length*/ ncoord);
     m_cfl = SimpleArray<double>(/*length*/ ncoord);
     m_so0 = SimpleArray<double>(/*shape*/ small_vector<size_t>{ncoord, NVAR});

--- a/cpp/modmesh/onedim/Euler1DCore.hpp
+++ b/cpp/modmesh/onedim/Euler1DCore.hpp
@@ -92,6 +92,9 @@ public:
 
     double time_increment() const { return m_time_increment; }
 
+    SimpleArray<int> const & pt_plot() const { return m_pt_plot; }
+    SimpleArray<int> & pt_plot() { return m_pt_plot; }
+
     size_t ncoord() const { return m_coord.size(); }
     SimpleArray<double> const & coord() const { return m_coord; }
     SimpleArray<double> & coord() { return m_coord; }
@@ -139,6 +142,7 @@ public:
 private:
 
     real_type m_time_increment = 0;
+    SimpleArray<int> m_pt_plot;
     SimpleArray<double> m_coord;
     SimpleArray<double> m_cfl;
     SimpleArray<double> m_so0;

--- a/cpp/modmesh/onedim/pymod/wrap_onedim.cpp
+++ b/cpp/modmesh/onedim/pymod/wrap_onedim.cpp
@@ -110,6 +110,10 @@ protected:
 
         (*this)
             .def_property_readonly(
+                "pt_plot",
+                [](wrapped_type & self)
+                { return to_ndarray(self.pt_plot()); })
+            .def_property_readonly(
                 "coord",
                 [](wrapped_type & self)
                 { return to_ndarray(self.coord()); })

--- a/modmesh/app/euler1d.py
+++ b/modmesh/app/euler1d.py
@@ -530,7 +530,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[::2]
+        x = self.st.svr.coord[self.st.svr.pt_plot]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots(3, 2)
@@ -574,7 +574,7 @@ class Euler1DApp():
 
         :return: FigureCanvas
         """
-        x = self.st.svr.coord[::2]
+        x = self.st.svr.coord[self.st.svr.pt_plot]
         fig = Figure()
         canvas = FigureCanvas(fig)
         ax = canvas.figure.subplots()
@@ -744,23 +744,23 @@ class Euler1DApp():
         """
         if self.use_grid_layout:
             self.density.update(adata=self.st.density_field,
-                                ndata=self.st.svr.density[::2])
+                                ndata=self.st.svr.density[self.st.svr.pt_plot])
             self.pressure.update(adata=self.st.pressure_field,
-                                 ndata=self.st.svr.pressure[::2])
+                                 ndata=self.st.svr.pressure[self.st.svr.pt_plot])
             self.velocity.update(adata=self.st.velocity_field,
-                                 ndata=self.st.svr.velocity[::2])
+                                 ndata=self.st.svr.velocity[self.st.svr.pt_plot])
             self.temperature.update(adata=self.st.temperature_field,
-                                    ndata=self.st.svr.temperature[::2])
+                                    ndata=self.st.svr.temperature[self.st.svr.pt_plot])
             self.internal_energy.update(adata=(self.st.internal_energy_field),
                                         ndata=(self.st.svr.
-                                               internal_energy[::2]))
+                                               internal_energy[self.st.svr.pt_plot]))
             self.entropy.update(adata=self.st.entropy_field,
-                                ndata=self.st.svr.entropy[::2])
+                                ndata=self.st.svr.entropy[self.st.svr.pt_plot])
         else:
             for name, is_selected, *_ in self.plot_config.state:
                 if is_selected:
                     eval(f'(self.{name}.update(adata=self.st.{name}_field,'
-                         f' ndata=self.st.svr.{name}[::2]))')
+                         f' ndata=self.st.svr.{name}[self.st.svr.pt_plot]))')
 
 
 class PlotArea(PuiInQt):

--- a/modmesh/onedim/euler1d.py
+++ b/modmesh/onedim/euler1d.py
@@ -38,6 +38,7 @@ class Euler1DSolver:
         svr = _impl.Euler1DCore(ncoord=ncoord, time_increment=time_increment)
 
         # Initialize spatial grid.
+        svr.pt_plot[...] = np.linspace(2, (ncoord - 3), num=((ncoord - 3) // 2), dtype=int)
         svr.coord[...] = np.linspace(xmin, xmax, num=ncoord)
 
         # Initialize field.
@@ -311,7 +312,7 @@ class ShockTube:
         :return: None
         """
         if None is coord:
-            coord = self.svr.coord[::2]  # Use the numerical solver.
+            coord = self.svr.coord[self.svr.pt_plot]  # Use the numerical solver.
         self.coord = coord.copy()  # Make a copy; no write back to argument.
 
         # Determine the zone location and the Boolean selection arrays.

--- a/startup.py
+++ b/startup.py
@@ -1,0 +1,3 @@
+import modmesh.view as mv
+
+mv.launch()


### PR DESCRIPTION
Following the issue https://github.com/solvcon/modmesh/pull/361
The PR sets the plotting points as an array 'pt_plot'. And then, it changes the points shown on the figure from coord[::2] to coord[self.st.svr.pt_plot].

However, there is something wrong in this code. It failed to create the variable 'svr.pt_plot' in 'modmesh/modmesh/onedim/euler1d.py'.